### PR TITLE
don't hang when Redis is unavailable

### DIFF
--- a/herring/herring/settings.py
+++ b/herring/herring/settings.py
@@ -115,6 +115,11 @@ REDIS_URL = env.get_value('REDIS_URL', default='redis://localhost:6379/0')
 
 # Celery queue
 CELERY_BROKER_URL = env.get_value('BROKER_URL', default=REDIS_URL)
+# max_retries here controls Celery's initial attempts to contact Redis, and
+# defaults to *infinity*. Using a slightly smaller number is useful, for
+# example, in development environments if the developer doesn't want to run a
+# whole Redis+Celery stack and is okay with integrations not working.
+CELERY_BROKER_TRANSPORT_OPTIONS = dict(max_retries=3)
 CELERY_REDBEAT_REDIS_URL = REDIS_URL
 CELERY_BEAT_SCHEDULER = 'redbeat.RedBeatScheduler'
 CELERY_BEAT_SCHEDULE = {


### PR DESCRIPTION
First, when Celery tasks make their initial attempt to connect to Redis,
set a limit of three tries before they raise an error.

Second, disable several tasks if such an error is raised on their first
call, so that subsequent server operations aren't slowed by attempting
to connect each time. (This has no effect if Redis becomes unavailable
sometime after the first call to one of these tasks is made.)